### PR TITLE
항목의 인덱스 번호와 관련한 작업

### DIFF
--- a/src/components/item-section/item-section.js
+++ b/src/components/item-section/item-section.js
@@ -2,7 +2,7 @@ import html from './item-section.html';
 import { handleAddItem, handleRefreshList } from './item/events.js';
 import './item-section.css';
 import './item/item.css';
-import { addItem, setLocalInfo } from './item/states.js';
+import { addItem, setLocalInfo, lists } from './item/states.js';
 import { storage } from './item/storage.js';
 
 function ItemSection() {
@@ -17,7 +17,7 @@ function ItemSection() {
   $addButton.addEventListener('click', () => {
     const newItem = addItem();
     if (!newItem) return;
-    handleAddItem(newItem);
+    handleAddItem(newItem, lists.length);
   });
 
   const initialId = storage.getItem('item_id', 0);
@@ -25,8 +25,8 @@ function ItemSection() {
   if (!newItem) return;
   const initialList = storage.getItem('item_lists',newItem);
   setLocalInfo(initialList, initialId);
-  initialList.map((e) => {
-    handleAddItem(e)
+  initialList.map((e, i) => {
+    handleAddItem(e, i + 1);
   })
 }
 

--- a/src/components/item-section/item/elements.js
+++ b/src/components/item-section/item/elements.js
@@ -14,14 +14,23 @@ export function createCheckbox(key,checked) {
 }
 
 export function createItemName(key,value) {
-  const $element = document.createElement('input');
-  $element.classList = 'item-section__item-name';
-  $element.setAttribute('type', 'text');
-  value.length?$element.setAttribute('value', value):$element.setAttribute('placeholder', '항목 이름');
-  $element.addEventListener('blur', (e) => {
+  const $wrapper = document.createElement('div');
+  $wrapper.classList = 'item-section__item-name';
+
+  const $index = document.createElement('span');
+  $index.classList = 'item-section__item-name-index';
+  $index.textContent = '123';
+
+  const $input = document.createElement('input');
+  $input.classList = 'item-section__item-name-input';
+  $input.setAttribute('type', 'text');
+  value.length ? $input.setAttribute('value', value) : $input.setAttribute('placeholder', '항목 이름');
+  $input.addEventListener('blur', (e) => {
     setValue(key, e.target.value);
   });
-  return $element;
+
+  $wrapper.append($index, $input);
+  return $wrapper;
 }
 
 export function createRatio(key,ratio) { //숫자타입 외에 다른 글자 입력 안되게 하기

--- a/src/components/item-section/item/elements.js
+++ b/src/components/item-section/item/elements.js
@@ -13,13 +13,13 @@ export function createCheckbox(key,checked) {
   return $element;
 }
 
-export function createItemName(key,value) {
+export function createItemName(key,value,index) {
   const $wrapper = document.createElement('div');
   $wrapper.classList = 'item-section__item-name';
 
   const $index = document.createElement('span');
   $index.classList = 'item-section__item-name-index';
-  $index.textContent = '123';
+  $index.textContent = index;
 
   const $input = document.createElement('input');
   $input.classList = 'item-section__item-name-input';
@@ -75,11 +75,22 @@ export function createRemoveButton($icon) {
   const $element = document.createElement('span');
   $element.classList = 'item-section__item-remove-button';
   $element.appendChild($icon);
-  $element.addEventListener('click', (e) => handleRemoveItem(e));
+  $element.addEventListener('click', (e) => {
+    handleRemoveItem(e);
+    updateItemIndexes();
+  });
   return $element;
 }
 
 export function updateListCount() {
   const $element = document.querySelector('#main .item-section__item-count');
   $element.textContent = `${lists.length} / 10`;
+}
+
+export function updateItemIndexes() {
+  document
+    .querySelectorAll('#main .item-section__item-name-index')
+    .forEach(($element, i) => {
+      $element.textContent = i + 1;
+  });
 }

--- a/src/components/item-section/item/events.js
+++ b/src/components/item-section/item/events.js
@@ -13,12 +13,12 @@ import { storage } from './storage.js';
 /**
  * 항목 아이템을 생성하여 문서에 추가합니다.
  */
-export const handleAddItem = ({key,value,checked,ratio}) => {
+export const handleAddItem = ({key,value,checked,ratio}, index) => {
   const $list = document.querySelector('#main .item-section__list');
 
   const $listItem = createListItem(key);
   const $checkbox = createCheckbox(key,checked);
-  const $itemName = createItemName(key,value);
+  const $itemName = createItemName(key,value,index);
   const $ratio = createRatio(key,ratio);
   const $removeButton = createRemoveButton(createCloseIcon());
 

--- a/src/components/item-section/item/item.css
+++ b/src/components/item-section/item/item.css
@@ -24,11 +24,27 @@
 
 .item-section__item-name {
   flex-grow: 1;
+  display: flex;
+  align-items: center;
+  padding: 0 0.75em;
   border: 1px solid #7f9bfe9e;
+  border-radius: 5px;
+  transition: all 0.25s;
 }
 
-.item-section__item-name:focus {
+.item-section__item-name:focus-within {
   box-shadow: 0px 0px 1px 1px #7f9bfe;
+}
+
+.item-section__item-name-index {
+  padding-right: 0.75em;
+  border-right: 1px solid #2A59FE;
+}
+
+.item-section__item-name-input {
+  flex-grow: 1;
+  padding-left: 0.75em;
+  border: none;
 }
 
 .item-section__item-ratio {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/itemsection#sh-from-hyesu => feat/itemsection#hyesu

### 변경 사항
- 항목의 인덱스를 표현하는 요소를 추가했습니다. 구현을 위해 전체를 덮고 있는 div 요소 내부에 span 과 input 요소가 존재하도록 했습니다.
  - 기존에 항목의 이름을 나타내는 Input 요소의 클래스 이름을 변경하였습니다.
    -  from `item-section__item-name`  to `item-section__item-name-input`
  - 인덱스 번호를 표현하는 요소의 클래스 이름은 `item-section__item-name-index` 입니다.
  - 전체 요소를 감싸고 있는 div 요소의 클래스 이름은 `item-section__item-name` 입니다.
- 항목 이름에 대한 요소를 생성하는 `createItemName()` 함수에 `index` 매개변수를 추가하여, `span` 요소에 텍스트를 부여할 수 있도록 했습니다.
- 전체 항목의 인덱스 요소의 정보를 업데이트하는 `updateItemIndexes()` 함수를 작성하고, 프로그램이 시작될 때나 항목 삭제 이벤트가 발생할 때 해당 함수를 사용하도록 했습니다.

### 테스트 결과
![image](https://github.com/prgrms-web-devcourse/FEDC4-simple-roulette/assets/50488780/47973b4c-9ce1-4313-a42f-86261866e0e1)

