### PR TITLE
항목 입력 최대 글자 지정

### DIFF
--- a/src/components/itemSection/ItemSection.js
+++ b/src/components/itemSection/ItemSection.js
@@ -77,6 +77,7 @@ export default class ItemSection {
             placeholder="항목 이름"
             type="text"
             value="${value}"
+            maxlength="20"
           />
         </div>
         <input
@@ -84,6 +85,7 @@ export default class ItemSection {
           placeholder="비율"
           type="text"
           value="${ratio}"
+          maxlength="20"
         />
         <span class="item-section__item-remove-button">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" width="20">


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/itemsection#sanghoon-> dev

### 변경 사항
항목 이름과 비율 입력 칸에 최대 20글자의 문자만 들어가도록 수정했습니다.
